### PR TITLE
Modified allowed licences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ lcov.info
 # Local settings
 .soroban
 .stellar
+
+# Contracts
+contracts/**/test_snapshots

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 repository = "https://github.com/NethermindEth/stellar-risc0-verifier"
 license = "Apache-2.0"
 
-
 [workspace.dependencies]
 soroban-sdk = "23.0.2"
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ unmaintained = "workspace"
 allow = [
     "0BSD",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSD-2-Clause-Patent",
@@ -58,10 +59,7 @@ allow = [
     "Xnet",
     "Zlib",
 ]
-exceptions = [
-    { name = "wasmparser", version = "*", allow = ["Apache-2.0 WITH LLVM-exception", "Apache-2.0", "MIT"] },
-    { name = "wasmparser-nostd", version = "*", allow = ["Apache-2.0 WITH LLVM-exception", "Apache-2.0", "MIT"] }
-]
+
 confidence-threshold = 0.8
 unused-allowed-license = "allow"
 


### PR DESCRIPTION
As part of https://github.com/NethermindEth/rust-template/pull/28 now we can add the `Apache-2.0 WITH LLVM-exception` to the allowed ones, so we might as well do it. I also fixed the gitignore a bit to reflect the same with the stellar private payment one. :smile: 