### PR TITLE
Add EmergencyStop contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "emergency-stop"
+version = "0.1.0"
+dependencies = [
+ "risc0-interface",
+ "soroban-sdk",
+ "stellar-access",
+ "stellar-contract-utils",
+ "stellar-macros",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1714,14 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-access"
+version = "0.6.0"
+source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=63167bb#63167bb707edf4ad25e46572df11d4332d10b68e"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "stellar-contract-utils"
 version = "0.6.0"
 source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=63167bb#63167bb707edf4ad25e46572df11d4332d10b68e"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -363,14 +363,14 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -390,14 +390,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -499,7 +499,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -514,12 +514,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -533,21 +533,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -558,18 +557,18 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -590,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -617,7 +616,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -706,7 +705,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -761,7 +760,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1019,15 +1018,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1047,18 +1046,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1080,7 +1079,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1121,7 +1120,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1144,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
@@ -1198,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1221,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1275,7 +1274,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1401,7 +1400,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1419,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
@@ -1439,14 +1438,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1501,7 +1500,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1582,14 +1581,14 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "25.1.0"
+version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c5285c83e7a5581879b7a65033eae53b24ac9689975aa6887f1d8ee3e941c9"
+checksum = "760124fb65a2acdea7d241b8efdfab9a39287ae8dc5bf8feb6fd9dfb664c1ad5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1601,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "25.1.0"
+version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1262aa83e99a0fb3e8cd56d6e5ca4c28ac4f9871ac7173f65301a8b9a12c20f"
+checksum = "5fb27e93f8d3fc3a815d24c60ec11e893c408a36693ec9c823322f954fa096ae"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1625,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "25.1.0"
+version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b62c526917a1e77b6dce3cd841b6c271f0fff344ea93ad92a8c45afe8051b6"
+checksum = "dec603a62a90abdef898f8402471a24d8b58a0043b9a998ed6a607a19a5dabe1"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -1640,16 +1639,17 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "25.1.0"
+version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0186c943a78de7038ce7eee478f521f7a7665440101ae0d24b4a59833fb6d833"
+checksum = "24718fac3af127fc6910eb6b1d3ccd8403201b6ef0aca73b5acabe4bc3dd42ed"
 dependencies = [
  "base64",
+ "sha2",
  "stellar-xdr",
  "thiserror",
  "wasmparser",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "25.1.0"
+version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a948196ed0633be3a4125e0c7a4fc0bb6337942e538813b1f171331738f9058"
+checksum = "93c558bca7a693ec8ed67d2d8c8f5b300f3772141d619a4a694ad5dd48461256"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1667,7 +1667,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror",
 ]
 
@@ -1743,7 +1743,7 @@ source = "git+https://github.com/OpenZeppelin/stellar-contracts?rev=63167bb#6316
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1837,7 +1837,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1890,9 +1890,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"
@@ -1908,7 +1908,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1919,9 +1919,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1932,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1942,22 +1942,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2020,7 +2020,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2060,22 +2060,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2095,11 +2095,11 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ sha2 = "0.10.9"
 stellar-access = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "63167bb" }
 stellar-macros = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "63167bb" }
 stellar-governance = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "63167bb" }
+stellar-contract-utils = { git = "https://github.com/OpenZeppelin/stellar-contracts", rev = "63167bb" }
 
 build-utils = { path = "tools/build-utils" }
 risc0-interface = { path = "contracts/interface"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
         "contracts/risc0-router",
         "contracts/mock-verifier",
         "contracts/timelock",
+        "contracts/emergency-stop",
         "tools/build-utils"
 ]
 resolver = "3"

--- a/contracts/emergency-stop/Cargo.toml
+++ b/contracts/emergency-stop/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "emergency-stop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+risc0-interface = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/emergency-stop/Cargo.toml
+++ b/contracts/emergency-stop/Cargo.toml
@@ -12,6 +12,9 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 risc0-interface = { workspace = true }
+stellar-access = { workspace = true }
+stellar-contract-utils = { workspace = true }
+stellar-macros = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/emergency-stop/src/lib.rs
+++ b/contracts/emergency-stop/src/lib.rs
@@ -60,9 +60,8 @@ impl RiscZeroVerifierEmergencyStop {
     }
 
     /// Permanently pauses verification via the circuit-breaker receipt.
+    #[when_not_paused]
     pub fn estop_with_receipt(env: Env, receipt: Receipt) {
-        pausable::when_not_paused(&env);
-
         let zero_digest = BytesN::from_array(&env, &ZERO_DIGEST);
         if receipt.claim_digest != zero_digest {
             panic_with_error!(&env, EmergencyStopError::InvalidProofOfExploit);

--- a/contracts/emergency-stop/src/lib.rs
+++ b/contracts/emergency-stop/src/lib.rs
@@ -1,0 +1,135 @@
+#![no_std]
+
+use risc0_interface::{Receipt, RiscZeroVerifierClient, RiscZeroVerifierInterface, VerifierError};
+use soroban_sdk::{
+    Address, Bytes, BytesN, Env, contract, contracterror, contractimpl, contracttype,
+    panic_with_error,
+};
+use stellar_access::ownable::{self, Ownable};
+use stellar_contract_utils::pausable::{self, Pausable};
+use stellar_macros::{only_owner, when_not_paused};
+
+#[cfg(test)]
+mod test;
+
+const ZERO_DIGEST: [u8; 32] = [0u8; 32];
+
+/// Storage keys used by the emergency stop contract.
+#[contracttype]
+pub enum DataKey {
+    /// Address of the verifier implementation being wrapped.
+    Verifier,
+}
+
+/// Errors emitted by the emergency stop wrapper.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum EmergencyStopError {
+    /// Caller is not authorized to perform the requested action.
+    Unauthorized = 1,
+    /// Verifier address is not configured.
+    VerifierNotSet = 5,
+    /// Receipt does not prove a circuit-breaker exploit.
+    InvalidProofOfExploit = 1001,
+    /// Unpause is not supported by the emergency stop wrapper.
+    UnpauseNotAllowed = 1002,
+}
+
+/// Emergency-stop wrapper for a RISC Zero verifier contract.
+#[contract]
+pub struct RiscZeroVerifierEmergencyStop;
+
+#[contractimpl]
+impl RiscZeroVerifierEmergencyStop {
+    /// Initializes the wrapper with an underlying verifier and guardian owner.
+    pub fn __constructor(env: Env, verifier: Address, owner: Address) {
+        env.storage().instance().set(&DataKey::Verifier, &verifier);
+        ownable::set_owner(&env, &owner);
+    }
+
+    /// Returns the verifier address wrapped by this contract.
+    pub fn get_verifier(env: Env) -> Address {
+        get_verifier(&env)
+    }
+
+    /// Permanently pauses verification. Only the guardian can call this.
+    #[only_owner]
+    pub fn estop(env: Env) {
+        pausable::pause(&env);
+    }
+
+    /// Permanently pauses verification via the circuit-breaker receipt.
+    pub fn estop_with_receipt(env: Env, receipt: Receipt) {
+        pausable::when_not_paused(&env);
+
+        let zero_digest = BytesN::from_array(&env, &ZERO_DIGEST);
+        if receipt.claim_digest != zero_digest {
+            panic_with_error!(&env, EmergencyStopError::InvalidProofOfExploit);
+        }
+
+        // Ensure the proof-of-exploit receipt is valid.
+        let _ = Self::verify_integrity(env.clone(), receipt);
+
+        pausable::pause(&env);
+    }
+}
+
+#[contractimpl]
+impl RiscZeroVerifierInterface for RiscZeroVerifierEmergencyStop {
+    type Proof = Bytes;
+
+    #[when_not_paused]
+    fn verify(
+        env: Env,
+        seal: Bytes,
+        image_id: BytesN<32>,
+        journal: BytesN<32>,
+    ) -> Result<(), VerifierError> {
+        let verifier = get_verifier(&env);
+        let client = RiscZeroVerifierClient::new(&env, &verifier);
+        client.verify(&seal, &image_id, &journal);
+        Ok(())
+    }
+
+    #[when_not_paused]
+    fn verify_integrity(env: Env, receipt: Receipt) -> Result<(), VerifierError> {
+        let verifier = get_verifier(&env);
+        let client = RiscZeroVerifierClient::new(&env, &verifier);
+        client.verify_integrity(&receipt);
+        Ok(())
+    }
+}
+
+#[contractimpl(contracttrait)]
+impl Ownable for RiscZeroVerifierEmergencyStop {}
+
+#[contractimpl]
+impl Pausable for RiscZeroVerifierEmergencyStop {
+    fn paused(env: &Env) -> bool {
+        pausable::paused(env)
+    }
+
+    fn pause(env: &Env, caller: Address) {
+        let owner = ownable::enforce_owner_auth(env);
+        if owner != caller {
+            panic_with_error!(env, EmergencyStopError::Unauthorized);
+        }
+        pausable::pause(env);
+    }
+
+    fn unpause(env: &Env, _caller: Address) {
+        panic_with_error!(env, EmergencyStopError::UnpauseNotAllowed);
+    }
+}
+
+fn get_verifier(env: &Env) -> Address {
+    match env
+        .storage()
+        .instance()
+        .get::<_, Address>(&DataKey::Verifier)
+    {
+        Some(verifier) => verifier,
+        None => panic_with_error!(env, EmergencyStopError::VerifierNotSet),
+    }
+}

--- a/contracts/emergency-stop/src/test.rs
+++ b/contracts/emergency-stop/src/test.rs
@@ -129,3 +129,12 @@ fn estop_with_receipt_pauses_and_calls_verifier() {
     assert!(client.paused());
     assert!(verifier_client.integrity_called());
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1002)")]
+fn unpause_always_panics() {
+    let (env, owner, client, _verifier_client) = setup();
+
+    env.mock_all_auths();
+    client.unpause(&owner);
+}

--- a/contracts/emergency-stop/src/test.rs
+++ b/contracts/emergency-stop/src/test.rs
@@ -1,0 +1,128 @@
+extern crate std;
+
+use risc0_interface::{Receipt, RiscZeroVerifierInterface, VerifierError};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::Address as _,
+    Address, Bytes, BytesN, Env,
+};
+
+use crate::{RiscZeroVerifierEmergencyStop, RiscZeroVerifierEmergencyStopClient};
+
+#[contract]
+struct MockVerifier;
+
+#[contracttype]
+enum MockKey {
+    IntegrityCalled,
+}
+
+#[contractimpl]
+impl MockVerifier {
+    pub fn integrity_called(env: Env) -> bool {
+        env.storage().instance().get(&MockKey::IntegrityCalled).unwrap_or(false)
+    }
+}
+
+#[contractimpl]
+impl RiscZeroVerifierInterface for MockVerifier {
+    type Proof = Bytes;
+
+    fn verify(
+        _env: Env,
+        _seal: Bytes,
+        _image_id: BytesN<32>,
+        _journal: BytesN<32>,
+    ) -> Result<(), VerifierError> {
+        Ok(())
+    }
+
+    fn verify_integrity(env: Env, _receipt: Receipt) -> Result<(), VerifierError> {
+        env.storage().instance().set(&MockKey::IntegrityCalled, &true);
+        Ok(())
+    }
+}
+
+fn setup() -> (
+    Env,
+    Address,
+    RiscZeroVerifierEmergencyStopClient<'static>,
+    MockVerifierClient<'static>,
+) {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let verifier_id = env.register(MockVerifier, ());
+    let verifier_client = MockVerifierClient::new(&env, &verifier_id);
+    let estop_id = env.register(RiscZeroVerifierEmergencyStop, (verifier_id, owner.clone()));
+    let estop_client = RiscZeroVerifierEmergencyStopClient::new(&env, &estop_id);
+    (env, owner, estop_client, verifier_client)
+}
+
+fn test_inputs(env: &Env) -> (Bytes, BytesN<32>, BytesN<32>) {
+    let seal = Bytes::from_slice(env, &[1, 2, 3]);
+    let image_id = BytesN::from_array(env, &[7u8; 32]);
+    let journal = BytesN::from_array(env, &[9u8; 32]);
+    (seal, image_id, journal)
+}
+
+#[test]
+fn forwards_verify_when_unpaused() {
+    let (env, _owner, client, _verifier_client) = setup();
+    let (seal, image_id, journal) = test_inputs(&env);
+
+    assert_eq!(client.verify(&seal, &image_id, &journal), ());
+}
+
+#[test]
+fn estop_sets_paused() {
+    let (env, _owner, client, _verifier_client) = setup();
+
+    env.mock_all_auths();
+    client.estop();
+
+    assert!(client.paused());
+}
+
+#[test]
+#[should_panic]
+fn estop_rejects_non_owner() {
+    let (_env, _owner, client, _verifier_client) = setup();
+    client.estop();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1000)")]
+fn verify_rejects_when_paused() {
+    let (env, _owner, client, _verifier_client) = setup();
+    let (seal, image_id, journal) = test_inputs(&env);
+
+    env.mock_all_auths();
+    client.estop();
+    client.verify(&seal, &image_id, &journal);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1001)")]
+fn estop_with_receipt_requires_zero_digest() {
+    let (env, _owner, client, _verifier_client) = setup();
+    let receipt = Receipt {
+        seal: Bytes::from_slice(&env, &[0xAA]),
+        claim_digest: BytesN::from_array(&env, &[1u8; 32]),
+    };
+
+    client.estop_with_receipt(&receipt);
+}
+
+#[test]
+fn estop_with_receipt_pauses_and_calls_verifier() {
+    let (env, _owner, client, verifier_client) = setup();
+    let receipt = Receipt {
+        seal: Bytes::from_slice(&env, &[0xBB]),
+        claim_digest: BytesN::from_array(&env, &[0u8; 32]),
+    };
+
+    client.estop_with_receipt(&receipt);
+
+    assert!(client.paused());
+    assert!(verifier_client.integrity_called());
+}

--- a/contracts/emergency-stop/src/test.rs
+++ b/contracts/emergency-stop/src/test.rs
@@ -2,9 +2,7 @@ extern crate std;
 
 use risc0_interface::{Receipt, RiscZeroVerifierInterface, VerifierError};
 use soroban_sdk::{
-    contract, contractimpl, contracttype,
-    testutils::Address as _,
-    Address, Bytes, BytesN, Env,
+    Address, Bytes, BytesN, Env, contract, contractimpl, contracttype, testutils::Address as _,
 };
 
 use crate::{RiscZeroVerifierEmergencyStop, RiscZeroVerifierEmergencyStopClient};
@@ -20,7 +18,10 @@ enum MockKey {
 #[contractimpl]
 impl MockVerifier {
     pub fn integrity_called(env: Env) -> bool {
-        env.storage().instance().get(&MockKey::IntegrityCalled).unwrap_or(false)
+        env.storage()
+            .instance()
+            .get(&MockKey::IntegrityCalled)
+            .unwrap_or(false)
     }
 }
 
@@ -38,7 +39,9 @@ impl RiscZeroVerifierInterface for MockVerifier {
     }
 
     fn verify_integrity(env: Env, _receipt: Receipt) -> Result<(), VerifierError> {
-        env.storage().instance().set(&MockKey::IntegrityCalled, &true);
+        env.storage()
+            .instance()
+            .set(&MockKey::IntegrityCalled, &true);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
This PR adds an emergency-stop smart contract that sits between the router and verifier, allowing verification to be permanently paused in incident scenarios. It introduces a guardian-controlled stop path plus a receipt-based stop path to trigger pause when an exploit proof is presented.

## Changes
- `contracts/emergency-stop`:
  - Added new `RiscZeroVerifierEmergencyStop` contract.
  - Added constructor wiring for wrapped verifier + owner.
  - Added pass-through verifier interface implementation:
    - `verify`
    - `verify_integrity`
  - Added emergency stop controls:
    - `estop` (owner-only)
    - `estop_with_receipt` (validates exploit receipt, then pauses)
  - Added pause/ownership behavior:
    - supports pause
    - explicitly disallows unpause (`UnpauseNotAllowed`) for permanent stop semantics
  - Added contract errors for authorization, verifier config, invalid exploit receipt, and unpause rejection.
- Tests:
  - Added contract test coverage for forwarding when active, pause behavior, auth checks, pause-gated verification, and receipt-driven stop flow.
- Workspace/deps:
  - Added `contracts/emergency-stop/Cargo.toml`
  - Updated workspace manifests and lockfile.

## Breaking changes
None.
