### PR TITLE
fix: handle verification result in estop_with_receipt

### DIFF
--- a/contracts/emergency-stop/src/lib.rs
+++ b/contracts/emergency-stop/src/lib.rs
@@ -68,7 +68,10 @@ impl RiscZeroVerifierEmergencyStop {
         }
 
         // Ensure the proof-of-exploit receipt is valid.
-        let _ = Self::verify_integrity(env.clone(), receipt);
+        // Do NOT discard the result — if verification fails, the contract
+        // must not be paused (pause is irreversible, there is no unpause).
+        Self::verify_integrity(env.clone(), receipt)
+            .unwrap_or_else(|_| panic_with_error!(&env, EmergencyStopError::InvalidProofOfExploit));
 
         pausable::pause(&env);
     }


### PR DESCRIPTION
## Summary

- Replaces `let _ = Self::verify_integrity(...)` with proper error handling in `estop_with_receipt()`
- If verification fails, the contract now panics with `InvalidProofOfExploit` instead of proceeding to an irreversible `pause()`

## Problem

The `let _ =` on line 71 of `emergency-stop/src/lib.rs` explicitly discards the `Result` from `verify_integrity()`. Since `pausable::pause()` is called unconditionally afterward — and the contract has no `unpause()` function — a failed verification would permanently freeze the contract.

Today this is masked by Soroban's cross-contract panic semantics, but the code is structurally wrong and becomes immediately exploitable if the verifier is refactored to return errors instead of panicking.

Full analysis: #22

## Test plan

- [ ] Verify `estop_with_receipt` with a valid zero-digest receipt still pauses correctly
- [ ] Verify `estop_with_receipt` with an invalid receipt now panics with `InvalidProofOfExploit` instead of pausing